### PR TITLE
libtn: add "show_picture" option

### DIFF
--- a/twitchnotifier.cfg
+++ b/twitchnotifier.cfg
@@ -35,3 +35,7 @@ notification_title_off=$1
 notification_content_off=is $2
 ; And when -l mode is used
 log_fmt_off=$1 -> $2 (${%H:%M})
+
+; Should a picture be shown together with the notification?
+; Accepted values are documented here: https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean.
+show_picture=no


### PR DESCRIPTION
Add a new option `show_picture` which makes TwitchNotifier try to
download the profile picture and show it in the notification.

For now, it is a simple, sequential solution. Tested manually on
localhost.